### PR TITLE
CDP detection fix

### DIFF
--- a/WATCHLISTS
+++ b/WATCHLISTS
@@ -142,7 +142,7 @@
     ],
     'merges': [
       # Only enabled on branches created with tools/release/create_release.py
-      # 'v8-merges@googlegroups.com',
+      'v8-merges@googlegroups.com',
     ],
     'wasm': [
       'wasm-v8@google.com',

--- a/gni/release_branch_toggle.gni
+++ b/gni/release_branch_toggle.gni
@@ -3,5 +3,5 @@
 # found in the LICENSE file.
 
 declare_args() {
-  v8_is_on_release_branch = false
+  v8_is_on_release_branch = true
 }

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 9
+#define V8_PATCH_LEVEL 10
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 3
+#define V8_PATCH_LEVEL 4
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 7
+#define V8_PATCH_LEVEL 8
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 1
+#define V8_PATCH_LEVEL 2
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 0
+#define V8_PATCH_LEVEL 1
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 4
+#define V8_PATCH_LEVEL 5
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 8
+#define V8_PATCH_LEVEL 9
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -9,12 +9,12 @@
 // NOTE these macros are used by some of the tool scripts and the build
 // system so their names cannot be changed without changing the scripts.
 #define V8_MAJOR_VERSION 13
-#define V8_MINOR_VERSION 7
-#define V8_BUILD_NUMBER 0
+#define V8_MINOR_VERSION 5
+#define V8_BUILD_NUMBER 212
 #define V8_PATCH_LEVEL 0
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)
-#define V8_IS_CANDIDATE_VERSION 1
+#define V8_IS_CANDIDATE_VERSION 0
 
 #endif  // V8_INCLUDE_VERSION_H_

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 5
+#define V8_PATCH_LEVEL 6
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 2
+#define V8_PATCH_LEVEL 3
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 13
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 212
-#define V8_PATCH_LEVEL 6
+#define V8_PATCH_LEVEL 7
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -32,20 +32,12 @@ namespace v8_inspector {
 
 namespace {
 
-String16 consoleContextToString(
-    v8::Isolate* isolate, const v8::debug::ConsoleContext& consoleContext) {
-  if (consoleContext.id() == 0) return String16();
-  return toProtocolString(isolate, consoleContext.name()) + "#" +
-         String16::fromInteger(consoleContext.id());
-}
-
 class ConsoleHelper {
  public:
   ConsoleHelper(const v8::debug::ConsoleCallArguments& info,
                 const v8::debug::ConsoleContext& consoleContext,
                 V8InspectorImpl* inspector)
       : m_info(info),
-        m_consoleContext(consoleContext),
         m_inspector(inspector) {}
 
   ConsoleHelper(const ConsoleHelper&) = delete;
@@ -105,44 +97,8 @@ class ConsoleHelper {
 
   void reportCall(ConsoleAPIType type,
                   v8::MemorySpan<const v8::Local<v8::Value>> arguments) {
-    if (!groupId()) return;
-    // Depending on the type of the console message, we capture only parts of
-    // the stack trace, or no stack trace at all.
-    std::unique_ptr<V8StackTraceImpl> stackTrace;
-    switch (type) {
-      case ConsoleAPIType::kTrace:
-        // The purpose of `console.trace()` is to output a stack trace to the
-        // developer tools console, therefore we should always strive to
-        // capture a full stack trace, even before any debugger is attached.
-        stackTrace = m_inspector->debugger()->captureStackTrace(true);
-        break;
-
-      case ConsoleAPIType::kTimeEnd:
-        // The `console.time()` and `console.timeEnd()` APIs are meant for
-        // performance investigations, and therefore it's important to reduce
-        // the total overhead of these calls, but also make sure these APIs
-        // have consistent performance overhead. In order to guarantee that,
-        // we always capture only the top frame, otherwise the performance
-        // characteristics of `console.timeEnd()` would differ based on the
-        // current call depth, which would skew the results.
-        //
-        // See https://crbug.com/41433391 for more information.
-        stackTrace = V8StackTraceImpl::capture(m_inspector->debugger(), 1);
-        break;
-
-      default:
-        // All other APIs get a full stack trace only when the debugger is
-        // attached, otherwise record only the top frame.
-        stackTrace = m_inspector->debugger()->captureStackTrace(false);
-        break;
-    }
-    std::unique_ptr<V8ConsoleMessage> message =
-        V8ConsoleMessage::createForConsoleAPI(
-            context(), contextId(), groupId(), m_inspector,
-            m_inspector->client()->currentTimeMS(), type, arguments,
-            consoleContextToString(isolate(), m_consoleContext),
-            std::move(stackTrace));
-    consoleMessageStorage()->addMessage(std::move(message));
+    // Prevent CDP detection by simply not logging anything. No serialization occurs.
+    return;
   }
 
   void reportDeprecatedCall(const char* id, const String16& message) {
@@ -196,7 +152,6 @@ class ConsoleHelper {
 
  private:
   const v8::debug::ConsoleCallArguments& m_info;
-  const v8::debug::ConsoleContext& m_consoleContext;
   V8InspectorImpl* m_inspector;
 };
 

--- a/src/maglev/maglev-graph-builder.cc
+++ b/src/maglev/maglev-graph-builder.cc
@@ -13324,21 +13324,21 @@ InlinedAllocation* MaglevGraphBuilder::BuildInlinedAllocation(
       break;
     case VirtualObject::kDefault: {
       SmallZoneVector<ValueNode*, 8> values(zone());
-      vobject->ForEachInput([&](ValueNode*& node) {
-        ValueNode* value_to_push;
-        if (node->Is<VirtualObject>()) {
-          VirtualObject* nested = node->Cast<VirtualObject>();
-          node = BuildInlinedAllocation(nested, allocation_type);
-          value_to_push = node;
-        } else if (node->Is<Float64Constant>()) {
-          value_to_push = BuildInlinedAllocationForHeapNumber(
-              CreateHeapNumber(node->Cast<Float64Constant>()->value()),
-              allocation_type);
-        } else {
-          value_to_push = GetTaggedValue(node);
-        }
-        values.push_back(value_to_push);
-      });
+      vobject->ForEachDeoptInputLocation(
+          [&](ValueNode* node, ValueNode*& input) {
+            if (node->Is<VirtualObject>()) {
+              VirtualObject* nested = node->Cast<VirtualObject>();
+              node = BuildInlinedAllocation(nested, allocation_type);
+              input = node;
+            } else if (node->Is<Float64Constant>()) {
+              node = BuildInlinedAllocationForHeapNumber(
+                  CreateHeapNumber(node->Cast<Float64Constant>()->value()),
+                  allocation_type);
+            } else {
+              node = GetTaggedValue(node);
+            }
+            values.push_back(node);
+          });
       allocation =
           ExtendOrReallocateCurrentAllocationBlock(allocation_type, vobject);
       AddNonEscapingUses(allocation, static_cast<int>(values.size()));


### PR DESCRIPTION
Disables console logging methods such as console.log.

This prevents bot protection from detecting the use of CDP during web scraping. Normally the use of CDP can be detected by overriding the Error.stack property and logging the error object.